### PR TITLE
Fix SVG icons in IE

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -254,7 +254,16 @@ MapboxGeocoder.prototype = {
     icon.setAttribute('xml:space','preserve');
     icon.setAttribute('width', 18);
     icon.setAttribute('height', 18);
-    icon.innerHTML = path;
+    // IE does not have innerHTML for SVG nodes
+    if (!('innerHTML' in icon)) {
+      var SVGNodeContainer = document.createElement('div');
+      SVGNodeContainer.innerHTML = '<svg>' + path.valueOf().toString() + '</svg>';
+      var SVGNode = SVGNodeContainer.firstChild,
+          SVGPath = SVGNode.firstChild;
+      icon.appendChild(SVGPath);
+    } else {
+      icon.innerHTML = path;
+    }
     return icon;
   },
 


### PR DESCRIPTION
 IE does not have innerHTML for SVG nodes, so instead we inject the path in a temporary node and then append it to the icon node.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
